### PR TITLE
Revert to a commit that works for race conditions handling

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1,0 +1,74 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        ruby:
+          - 2.5
+          - 2.6
+          - 2.7
+          - 3.0
+          - ruby-head
+          - jruby
+        gemfile:
+          - ar52
+          - ar60
+          - ar61
+          - ar-head
+        exclude:
+          - gemfile: ar52
+            ruby: 3.0
+          - gemfile: ar52
+            ruby: ruby-head
+    continue-on-error: ${{ matrix.ruby == 'jruby' || matrix.ruby == 'ruby-head' || matrix.gemfile == 'ar-head' }}
+    services:
+      postgres:
+        image: postgis/postgis:12-3.1
+        ports:
+          - 5432:5432
+        env:
+          POSTGRES_HOST_AUTH_METHOD: trust
+          POSTGRES_DB: makara_test
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+      mysql:
+        image: mysql:5.7
+        env:
+          MYSQL_ALLOW_EMPTY_PASSWORD: yes
+          MYSQL_DATABASE: makara_test
+        ports:
+          - 3306:3306
+        options: >-
+          --health-cmd "mysqladmin ping"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+    env:
+       BUNDLE_GEMFILE: gemfiles/${{ matrix.gemfile }}.gemfile
+       JRUBY_OPTS: --dev -J-Xmx1024M
+    steps:
+      - uses: actions/checkout@v2
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby }}
+          bundler-cache: true
+      - run: |
+          bundle exec rake
+        env:
+          PGHOST: localhost
+          PGUSER: postgres
+          MYSQL_HOST: 127.0.0.1
+          RAILS_ENV: test
+

--- a/lib/makara/proxy.rb
+++ b/lib/makara/proxy.rb
@@ -119,7 +119,7 @@ module Makara
       any_connection do |con|
         con._makara_connection.respond_to?(m, true)
       end
-    RUBY_EVAL
+    end
 
     def graceful_connection_for(config)
       fake_wrapper = Makara::ConnectionWrapper.new(self, nil, config)

--- a/lib/makara/proxy.rb
+++ b/lib/makara/proxy.rb
@@ -23,19 +23,23 @@ module Makara
         self.hijack_methods |= method_names
 
         method_names.each do |method_name|
-          define_method method_name do |*args, &block|
+          define_method(method_name) do |*args, &block|
             appropriate_connection(method_name, args) do |con|
               con.send(method_name, *args, &block)
             end
           end
+
+          ruby2_keywords method_name if Module.private_method_defined?(:ruby2_keywords)
         end
       end
 
       def send_to_all(*method_names)
         method_names.each do |method_name|
-          define_method method_name do |*args|
-            send_to_all method_name, *args
+          define_method(method_name) do |*args|
+            send_to_all(method_name, *args)
           end
+
+          ruby2_keywords method_name if Module.private_method_defined?(:ruby2_keywords)
         end
       end
     end
@@ -97,25 +101,23 @@ module Makara
 
     def method_missing(m, *args, &block)
       if METHOD_MISSING_SKIP.include?(m)
-        return super(m, *args, &block)
+        return super
       end
 
       any_connection do |con|
-        if con.respond_to?(m)
-          con.public_send(m, *args, &block)
-        elsif con.respond_to?(m, true)
-          con.__send__(m, *args, &block)
+        if con.respond_to?(m, true)
+          con.send(m, *args, &block)
         else
-          super(m, *args, &block)
+          super
         end
       end
     end
 
-    class_eval <<-RUBY_EVAL, __FILE__, __LINE__ + 1
-      def respond_to#{RUBY_VERSION.to_s =~ /^1.8/ ? nil : '_missing'}?(m, include_private = false)
-        any_connection do |con|
-          con._makara_connection.respond_to?(m, true)
-        end
+    ruby2_keywords :method_missing if Module.private_method_defined?(:ruby2_keywords)
+
+    def respond_to_missing?(m, include_private = false)
+      any_connection do |con|
+        con._makara_connection.respond_to?(m, true)
       end
     RUBY_EVAL
 
@@ -138,7 +140,6 @@ module Makara
 
     protected
 
-
     def send_to_all(method_name, *args)
       # slave pool must run first to allow for slave-->master failover without running operations on master twice.
       handling_an_all_execution(method_name) do
@@ -146,6 +147,8 @@ module Makara
         @master_pool.send_to_all method_name, *args
       end
     end
+
+    ruby2_keywords :send_to_all if Module.private_method_defined?(:ruby2_keywords)
 
     def any_connection
       @master_pool.provide do |con|

--- a/makara.gemspec
+++ b/makara.gemspec
@@ -9,7 +9,7 @@ Gem::Specification.new do |gem|
   gem.homepage      = "https://github.com/taskrabbit/makara"
   gem.licenses      = ['MIT']
   gem.metadata      = {
-                        source_code_uri: 'https://github.com/taskrabbit/makara'
+                        'source_code_uri' => 'https://github.com/taskrabbit/makara'
                       }
 
   gem.files         = `git ls-files`.split($\)

--- a/spec/active_record/connection_adapters/makara_mysql2_adapter_spec.rb
+++ b/spec/active_record/connection_adapters/makara_mysql2_adapter_spec.rb
@@ -166,9 +166,17 @@ describe 'MakaraMysql2Adapter' do
       
       con = connection.slave_pool.connections.first
       if (ActiveRecord::VERSION::MAJOR == 5 && ActiveRecord::VERSION::MINOR <= 0)
-        expect(con).to receive(:execute).with(/SELECT\s+1\s*(AS one)?\s+FROM .?users.?\s+LIMIT\s+.?1/, any_args).once.and_call_original
+        expect(con).to receive(:execute) do |query|
+          expect(query).to match(/SELECT\s+1\s*(AS one)?\s+FROM .?users.?\s+LIMIT\s+.?1/)
+        end.once.
+          # and_call_original # Switch back to this once https://github.com/rspec/rspec-mocks/pull/1385 is released
+          and_wrap_original { |m, *args| m.call(*args.first(3)) }
       else
-        expect(con).to receive(:exec_query).with(/SELECT\s+1\s*(AS one)?\s+FROM .?users.?\s+LIMIT\s+.?1/, any_args).once.and_call_original
+        expect(con).to receive(:exec_query) do |query|
+          expect(query).to match(/SELECT\s+1\s*(AS one)?\s+FROM .?users.?\s+LIMIT\s+.?1/)
+        end.once.
+          # and_call_original # Switch back to this once https://github.com/rspec/rspec-mocks/pull/1385 is released
+          and_wrap_original { |m, *args| m.call(*args.first(3)) }
       end
       Test::User.exists?
     end

--- a/spec/active_record/connection_adapters/makara_mysql2_adapter_spec.rb
+++ b/spec/active_record/connection_adapters/makara_mysql2_adapter_spec.rb
@@ -168,15 +168,11 @@ describe 'MakaraMysql2Adapter' do
       if (ActiveRecord::VERSION::MAJOR == 5 && ActiveRecord::VERSION::MINOR <= 0)
         expect(con).to receive(:execute) do |query|
           expect(query).to match(/SELECT\s+1\s*(AS one)?\s+FROM .?users.?\s+LIMIT\s+.?1/)
-        end.once.
-          # and_call_original # Switch back to this once https://github.com/rspec/rspec-mocks/pull/1385 is released
-          and_wrap_original { |m, *args| m.call(*args.first(3)) }
+        end.once.and_call_original
       else
         expect(con).to receive(:exec_query) do |query|
           expect(query).to match(/SELECT\s+1\s*(AS one)?\s+FROM .?users.?\s+LIMIT\s+.?1/)
-        end.once.
-          # and_call_original # Switch back to this once https://github.com/rspec/rspec-mocks/pull/1385 is released
-          and_wrap_original { |m, *args| m.call(*args.first(3)) }
+        end.once.and_call_original
       end
       Test::User.exists?
     end

--- a/spec/active_record/connection_adapters/makara_postgresql_adapter_spec.rb
+++ b/spec/active_record/connection_adapters/makara_postgresql_adapter_spec.rb
@@ -81,9 +81,17 @@ describe 'MakaraPostgreSQLAdapter' do
       con = connection.slave_pool.connections.first
       if (ActiveRecord::VERSION::MAJOR == 4 && ActiveRecord::VERSION::MINOR >= 2) ||
          (ActiveRecord::VERSION::MAJOR == 5 && ActiveRecord::VERSION::MINOR <= 0)
-        expect(con).to receive(:exec_no_cache).with(/SELECT\s+1\s*(AS one)?\s+FROM .?users.?\s+LIMIT\s+.?1/, any_args).once.and_call_original
+        expect(con).to receive(:exec_no_cache) do |query|
+          expect(query).to match(/SELECT\s+1\s*(AS one)?\s+FROM .?users.?\s+LIMIT\s+.?1/)
+        end.once.
+          # and_call_original # Switch back to this once https://github.com/rspec/rspec-mocks/pull/1385 is released
+          and_wrap_original { |m, *args| m.call(*args.first(3)) }
       else
-        expect(con).to receive(:exec_query).with(/SELECT\s+1\s*(AS one)?\s+FROM .?users.?\s+LIMIT\s+.?1/, any_args).once.and_call_original
+        expect(con).to receive(:exec_query) do |query|
+          expect(query).to match(/SELECT\s+1\s*(AS one)?\s+FROM .?users.?\s+LIMIT\s+.?1/)
+        end.once.
+          # and_call_original # Switch back to this once https://github.com/rspec/rspec-mocks/pull/1385 is released
+          and_wrap_original { |m, *args| m.call(*args.first(3)) }
       end
       Test::User.exists?
     end

--- a/spec/active_record/connection_adapters/makara_postgresql_adapter_spec.rb
+++ b/spec/active_record/connection_adapters/makara_postgresql_adapter_spec.rb
@@ -83,15 +83,11 @@ describe 'MakaraPostgreSQLAdapter' do
          (ActiveRecord::VERSION::MAJOR == 5 && ActiveRecord::VERSION::MINOR <= 0)
         expect(con).to receive(:exec_no_cache) do |query|
           expect(query).to match(/SELECT\s+1\s*(AS one)?\s+FROM .?users.?\s+LIMIT\s+.?1/)
-        end.once.
-          # and_call_original # Switch back to this once https://github.com/rspec/rspec-mocks/pull/1385 is released
-          and_wrap_original { |m, *args| m.call(*args.first(3)) }
+        end.once.and_call_original
       else
         expect(con).to receive(:exec_query) do |query|
           expect(query).to match(/SELECT\s+1\s*(AS one)?\s+FROM .?users.?\s+LIMIT\s+.?1/)
-        end.once.
-          # and_call_original # Switch back to this once https://github.com/rspec/rspec-mocks/pull/1385 is released
-          and_wrap_original { |m, *args| m.call(*args.first(3)) }
+        end.once.and_call_original
       end
       Test::User.exists?
     end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -18,13 +18,6 @@ if RUBY_VERSION >= "2.7.0"
   Warning[:deprecated] = true
 end
 
-# Delete once Timecop fixes Ruby 3.1 support
-Time.class_eval do
-  class << self
-    ruby2_keywords :new if Module.private_method_defined?(:ruby2_keywords)
-  end
-end
-
 RSpec.configure do |config|
   config.run_all_when_everything_filtered = true
   config.filter_run :focus

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -14,6 +14,17 @@ begin
 rescue LoadError
 end
 
+if RUBY_VERSION >= "2.7.0"
+  Warning[:deprecated] = true
+end
+
+# Delete once Timecop fixes Ruby 3.1 support
+Time.class_eval do
+  class << self
+    ruby2_keywords :new if Module.private_method_defined?(:ruby2_keywords)
+  end
+end
+
 RSpec.configure do |config|
   config.run_all_when_everything_filtered = true
   config.filter_run :focus


### PR DESCRIPTION
## Background

Creating this PR to document why we reverted to this [commit](https://github.com/instacart/makara/commit/bf530f996341113c797dcd21742656301cf5b9c9).

The addition from this [commit](https://github.com/instacart/makara/commit/1140b166d7b311e9645f974bd1d1cf9239854bcd) broke race conditions handling.

Through a simple [Rails app](https://github.com/gohkhoonhiang/makara_test_app) setup, it shows that introducing `ActiveRecordPoolControl` caused 2 instances of `LoadInterlockAwareMonitor` to be created, and cannot effectively synchronise multiple threads accessing the same DB rows.

To unblock our ruby3 upgrade, we will revert back to the commit that has worked before the introducing of the `ActiveRecordPoolControl` class.

## Commits cherry-picked from upstream

- [Fix on Ruby 3](https://github.com/instacart/makara/commit/14dec405fe13cff739a9d86a17226ced0699c4f4)
- [Remove Rspec hack](https://github.com/instacart/makara/commit/870abec6bf05451fdb7a8c305bd957473a41ff20)
- [Remove timecop monkeypatch](https://github.com/instacart/makara/commit/e45ba090fce998dad9e9a2759426f4695009cfae)